### PR TITLE
fix: remove strict typescript version

### DIFF
--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -14,6 +14,6 @@
     "url": "https://github.com/nextrequest/configs/issues"
   },
   "peerDependencies": {
-    "typescript": ">=3.3.1 <4.6.0"
+    "typescript": ">=3.3.1"
   }
 }


### PR DESCRIPTION
Removes the strict typescript version to allow the typescript checker to work with the latest version of typescript.