### PR TITLE
chore(release): publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ npm install | yarn add @nextrequestco/typescript-config@latest
 
 ## Updating release version
 
+Make sure to merge in the latest code changes into main before running the following steps:
+
 1. Create a new branch
-2. cd into the correct package you want to update. For example `configs/packages/typescript-config` then run the lerna publish command.
+2. Then run the lerna publish command. Lerna will automatically detect any new changes since the last version release.
 
 ref: https://lerna.js.org/docs/features/version-and-publish
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# `@nextrequestco/configs`
+
+## NextRequest module configuration presets
+
+## Installation
+
+```
+npm install | yarn add @nextrequestco/commitlint-config@latest
+npm install | yarn add @nextrequestco/eslint-config@latest
+npm install | yarn add @nextrequestco/prettier-config@latest
+npm install | yarn add @nextrequestco/typescript-config@latest
+
+```
+
+## Updating release version
+
+1. Create a new branch
+2. cd into the correct package you want to update. For example `configs/packages/typescript-config` then run the lerna version command.
+
+ref: https://lerna.js.org/docs/features/version-and-publish
+
+```
+npx lerna version
+
+```
+
+3. Make sure the new version is pushed into the new branch
+4. Request a PR reviewer and once approved, merge the new version into `main`

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ npm install | yarn add @nextrequestco/typescript-config@latest
 ## Updating release version
 
 1. Create a new branch
-2. cd into the correct package you want to update. For example `configs/packages/typescript-config` then run the lerna version command.
+2. cd into the correct package you want to update. For example `configs/packages/typescript-config` then run the lerna publish command.
 
 ref: https://lerna.js.org/docs/features/version-and-publish
 
 ```
-npx lerna version
+npx lerna publish
 ```
 
 3. Make sure the new version is pushed into the new branch

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ npm install | yarn add @nextrequestco/commitlint-config@latest
 npm install | yarn add @nextrequestco/eslint-config@latest
 npm install | yarn add @nextrequestco/prettier-config@latest
 npm install | yarn add @nextrequestco/typescript-config@latest
-
 ```
 
 ## Updating release version
@@ -21,7 +20,6 @@ ref: https://lerna.js.org/docs/features/version-and-publish
 
 ```
 npx lerna version
-
 ```
 
 3. Make sure the new version is pushed into the new branch

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextrequestco/typescript-config",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "NextRequest Engineering <engineering@nextrequest.com>",
   "homepage": "https://github.com/nextrequest/configs#readme",
   "license": "UNLICENSED",

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextrequestco/typescript-config",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": "NextRequest Engineering <engineering@nextrequest.com>",
   "homepage": "https://github.com/nextrequest/configs#readme",
   "license": "UNLICENSED",


### PR DESCRIPTION
 @nextrequestco/typescript-config@1.2.0
 - Commits new release version
 - Add a README.md to explain how to install and release new versions of the package. 
 - I went from 1.0 to 1.2 since I accidentally updated the 1.1 release without publishing.
 
 This new version 1.2 can be tested in the components PR: https://github.com/nextrequest/components/pull/404
 