### PR TITLE
feat(eslint)!: enforce that interface names do not begin with an I

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -20,6 +20,19 @@ module.exports = {
       {
         argsIgnorePattern: '^_'
       }
+    ],
+    // Enforce that interface names do not begin with an I.
+    // Taken from https://typescript-eslint.io/rules/naming-convention/#enforce-that-interface-names-do-not-begin-with-an-i
+    "@typescript-eslint/naming-convention": [
+      "error",
+      {
+        "selector": "interface",
+        "format": ["PascalCase"],
+        "custom": {
+          "regex": "^I[A-Z]",
+          "match": false
+        }
+      }
     ]
   }
 }


### PR DESCRIPTION
The current (unenforced) convention in NextRequest is to prefix typescript interface names with `I`. This PR proposes enforcing the opposite: that interface names are not prefixed with `I`. Note that it still allows names where the first character is `I` and the second is lowercase: `Invoice` is OK but not `IInvoice`.

I am not used to interface names prefixed with `I`, so personally it doesn't feel like it is useful information. That's not a technical argument though, and if others find it useful then I'm happy to keep it!

Most of what I've read recommends not using `I`:
- https://dev.to/mscamargo/why-you-should-avoid-using-the-i-prefix-for-interfaces-in-typescript-43gd
- https://passionfordev.com/you-dont-need-to-prefix-interfaces-in-typescript-with-i/
- The typescript codebase's own style guide: https://github.com/Microsoft/TypeScript/wiki/Coding-guidelines#names

If this were to be merged we would then have to.
1. Open a PR on `nextrequest` that updates the version of this config package and updates all the interface names.
2. Do the same in `components`.