### PR TITLE
chore(release): publish

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextrequestco/eslint-config",
-  "version": "1.4.3",
+  "version": "2.0.0",
   "author": "NextRequest Engineering <engineering@nextrequest.com>",
   "homepage": "https://github.com/nextrequest/configs#readme",
   "license": "UNLICENSED",

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextrequestco/typescript-config",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": "NextRequest Engineering <engineering@nextrequest.com>",
   "homepage": "https://github.com/nextrequest/configs#readme",
   "license": "UNLICENSED",


### PR DESCRIPTION
 - @nextrequestco/eslint-config@2.0.0
 - @nextrequestco/typescript-config@1.3.0

I'm not sure why the typescript-config version got bumped.